### PR TITLE
Fixed missing header in wp-dos-patch.sh

### DIFF
--- a/wp-dos-patch.sh
+++ b/wp-dos-patch.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 if [[ -f wp-login.php && -f wp-admin/load-scripts.php && -f wp-admin/includes/noop.php ]]
 then
         sed -i "1 s/^.*$/<?php\ndefine('CONCATENATE_SCRIPTS', false);/" wp-login.php


### PR DESCRIPTION
Small change in `wp-dos-patch.sh` to add `#! /bin/bash`.